### PR TITLE
fix booklet pagination issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ book.ind
 book.log
 book.idx
 modes/curmode.tex
+book.fdb_latexmk
+book.fls

--- a/modes/handout.tex
+++ b/modes/handout.tex
@@ -1,2 +1,3 @@
 \documentclass[twoside,10pt,openany,letterpaper]{memoir}
 \usepackage[noprint,1to1]{booklet}
+\pagespersignature{120}


### PR DESCRIPTION
Booklet pagination breaks after 32 pages. Inserting \pagespersignature{120} should fix it, but have not been able to test.