### PR TITLE
Edits noticed at 2023 carol singing

### DIFF
--- a/carols/good_king.ly
+++ b/carols/good_king.ly
@@ -134,7 +134,7 @@ accomp=\chordmode {
 
 
 stanzaa = \lyricmode {
-  Good King Wen -- ces -- lass looked out
+  Good King Wen -- ces -- las looked out
   On the feast of Ste -- phen,
   When the snow lay round a -- bout,
   Deep and crisp and e -- ven;

--- a/carols/riu.ly
+++ b/carols/riu.ly
@@ -307,7 +307,7 @@ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
 Es -- te que~es na -- ci -- do
 es _ el gran mo -- \mt #1 nar-ca,
 Cris -- to pa -- tri -- ar -- ca
-de car -- _ ne ves -- \mt #1 ti-do;
+de car -- ne ves -- ti -- do;
 ha -- nos re -- di -- mi -- do
 con se ha -- cer chi -- \mt #1 qui-to
 aun -- que~e -- ra~in -- fi -- ni -- to,

--- a/carols/wexford.ly
+++ b/carols/wexford.ly
@@ -169,7 +169,7 @@ tenorMusic = \relative c {
   g |
   g c b( a4) c8 |
   
-  d8 a f4. g8 |
+  d8 a f?4. g8 |
   \times 2/3 {g[ a] bes} bes[ a] bes[ c] |
   a c a4 r8 d, |
   


### PR DESCRIPTION
A few things I/we noticed at last weekend's carol singing party:

- In "Good King Wenceslas", the king's name is misspelled once
- In "Riu Riu Chiu", syllables don't line up well with notes in the final two measures of the first line of the second verse
- In "Wexford Carol", added a courtesy natural for tenors in m10, reflecting the F natural from the bass part in the previous beat